### PR TITLE
Add mute and unmute command (fix #29)

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -191,6 +191,7 @@ async def on_ready():
     if not send_holiday.is_running():
         logger.info("Starting holiday task")
         send_holiday.start()
+
     await clean_db()
 
 
@@ -314,10 +315,12 @@ async def on_voice_state_update(
         # Can't mute bert hehehe
         await member.edit(mute=False)
         return
-    #mute command
+
+    # Mute command
     if before.mute and not after.mute and member.id in muted_users:
-            await member.edit(mute=True)
-            return
+        await member.edit(mute=True)
+        return
+
     if before.channel != after.channel:  # User moved channels
         if before.channel:
             if not [
@@ -496,50 +499,68 @@ async def _bert(interaction: discord.Interaction):
     """bert"""
     await interaction.response.send_message(interaction.user.mention)
 
+
 muted_users = set()
 unmutables = (747766456820695072,)
 
-@bert.user_command()
+
 @bert.slash_command()
+@bert.user_command()
 async def mute(interaction: discord.Interaction, user: discord.Member):
     """Mute a user permanently"""
     if user == interaction.user:
-        await interaction.response.send_message("You can't mute yourself", ephemeral=True)
+        await interaction.response.send_message(
+            "You can't mute yourself", ephemeral=True
+        )
         return
     if user.bot:
         await interaction.response.send_message("You can't mute a bot", ephemeral=True)
         return
     if user.id in muted_users:
-        await interaction.response.send_message(f"{user.display_name} is already muted", ephemeral=True)
+        await interaction.response.send_message(
+            f"{user.display_name} is already muted", ephemeral=True
+        )
         return
     if user in (await bert.application_info()).team.members or user.id in unmutables:
         await interaction.response.send_message("nuh uh", ephemeral=True)
         return
     muted_users.add(user.id)
-    await interaction.response.send_message(f"Muted {user.display_name}", ephemeral=True)
+    await interaction.response.send_message(
+        f"Muted {user.display_name}", ephemeral=True
+    )
     if user.voice:
         await user.edit(mute=True)
 
-@bert.user_command()
+
 @bert.slash_command()
+@bert.user_command()
 async def unmute(interaction: discord.Interaction, user: discord.Member):
     """Unmute a user"""
     if user == interaction.user:
-        await interaction.response.send_message("You can't unmute yourself", ephemeral=True)
+        await interaction.response.send_message(
+            "You can't unmute yourself", ephemeral=True
+        )
         return
     if user.bot:
-        await interaction.response.send_message("You can't unmute a bot", ephemeral=True)
+        await interaction.response.send_message(
+            "You can't unmute a bot", ephemeral=True
+        )
         return
     if user.id not in muted_users:
-        await interaction.response.send_message(f"{user.display_name} is not muted", ephemeral=True)
+        await interaction.response.send_message(
+            f"{user.display_name} is not muted", ephemeral=True
+        )
         return
     if user in (await bert.application_info()).team.members or user.id in unmutables:
         await interaction.response.send_message("nuh uh", ephemeral=True)
         return
     muted_users.remove(user.id)
-    await interaction.response.send_message(f"Unmuted {user.display_name}", ephemeral=True)
+    await interaction.response.send_message(
+        f"Unmuted {user.display_name}", ephemeral=True
+    )
     if user.voice:
         await user.edit(mute=False)
+
 
 @bert.slash_command()
 @option("user", description="The user to send messages to")

--- a/bot/main.py
+++ b/bot/main.py
@@ -30,7 +30,7 @@ load_dotenv()
 bert = commands.Bot(
     command_prefix="bert ",
     intents=discord.Intents.all(),
-    debug_guilds=[870973430114181141, 1182803938517455008],
+    # debug_guilds=[870973430114181141, 1182803938517455008],
 )
 
 TZ = ZoneInfo(os.getenv("TZ") or "Europe/Amsterdam")

--- a/bot/main.py
+++ b/bot/main.py
@@ -179,8 +179,6 @@ async def clean_db():
 
 @bert.event
 async def on_ready():
-    global team_members
-    team_members = [member.id for member in (await bert.application_info()).team.members]
     logger.info("%s is ready to hurt your brain", bert.user.name)
 
     logger.info("Connecting to Lavalink nodes")
@@ -508,7 +506,7 @@ async def mute(interaction: discord.Interaction, user: discord.Member):
     if user.bot:
         await interaction.response.send_message("You can't mute a bot", ephemeral=True)
         return
-    if user.id in team_members or user.id in unmutables:
+    if user.id in [member.id for member in (await bert.application_info()).team.members] or user.id in unmutables:
         await interaction.response.send_message("nuh uh", ephemeral=True)
         return
     if user == interaction.user:
@@ -528,19 +526,19 @@ async def mute(interaction: discord.Interaction, user: discord.Member):
 async def unmute(interaction: discord.Interaction, user: discord.Member):
     """Unmute a user"""
     if user.bot:
-        await interaction.response.send_message("You can't unmute a bot", ephemeral=True, delete_after=5)
+        await interaction.response.send_message("You can't unmute a bot", ephemeral=True)
         return
-    if user.id in team_members or user.id in unmutables:
-        await interaction.response.send_message("nuh uh", ephemeral=True, delete_after=5)
+    if user.id in [member.id for member in (await bert.application_info()).team.members] or user.id in unmutables:
+        await interaction.response.send_message("nuh uh", ephemeral=True)
         return
     if user == interaction.user:
-        await interaction.response.send_message("You can't unmute yourself", ephemeral=True, delete_after=5)
+        await interaction.response.send_message("You can't unmute yourself", ephemeral=True)
         return
     if user.id not in muted_users:
-        await interaction.response.send_message(f"{user.display_name} is not muted", ephemeral=True, delete_after=5)
+        await interaction.response.send_message(f"{user.display_name} is not muted", ephemeral=True)
         return
     muted_users.remove(user.id)
-    await interaction.response.send_message(f"Unmuted {user.display_name}", ephemeral=True, delete_after=5)
+    await interaction.response.send_message(f"Unmuted {user.display_name}", ephemeral=True)
     if user.voice is None:
         return
     await user.edit(mute=False)

--- a/bot/main.py
+++ b/bot/main.py
@@ -503,45 +503,43 @@ unmutables = (747766456820695072,)
 @bert.slash_command()
 async def mute(interaction: discord.Interaction, user: discord.Member):
     """Mute a user permanently"""
-    if user.bot:
-        await interaction.response.send_message("You can't mute a bot", ephemeral=True)
-        return
-    if user.id in [member.id for member in (await bert.application_info()).team.members] or user.id in unmutables:
-        await interaction.response.send_message("nuh uh", ephemeral=True)
-        return
     if user == interaction.user:
         await interaction.response.send_message("You can't mute yourself", ephemeral=True)
+        return
+    if user.bot:
+        await interaction.response.send_message("You can't mute a bot", ephemeral=True)
         return
     if user.id in muted_users:
         await interaction.response.send_message(f"{user.display_name} is already muted", ephemeral=True)
         return
+    if user in (await bert.application_info()).team.members or user.id in unmutables:
+        await interaction.response.send_message("nuh uh", ephemeral=True)
+        return
     muted_users.add(user.id)
     await interaction.response.send_message(f"Muted {user.display_name}", ephemeral=True)
-    if user.voice is None:
-        return
-    await user.edit(mute=True)
+    if user.voice:
+        await user.edit(mute=True)
 
 @bert.user_command()
 @bert.slash_command()
 async def unmute(interaction: discord.Interaction, user: discord.Member):
     """Unmute a user"""
-    if user.bot:
-        await interaction.response.send_message("You can't unmute a bot", ephemeral=True)
-        return
-    if user.id in [member.id for member in (await bert.application_info()).team.members] or user.id in unmutables:
-        await interaction.response.send_message("nuh uh", ephemeral=True)
-        return
     if user == interaction.user:
         await interaction.response.send_message("You can't unmute yourself", ephemeral=True)
+        return
+    if user.bot:
+        await interaction.response.send_message("You can't unmute a bot", ephemeral=True)
         return
     if user.id not in muted_users:
         await interaction.response.send_message(f"{user.display_name} is not muted", ephemeral=True)
         return
+    if user in (await bert.application_info()).team.members or user.id in unmutables:
+        await interaction.response.send_message("nuh uh", ephemeral=True)
+        return
     muted_users.remove(user.id)
     await interaction.response.send_message(f"Unmuted {user.display_name}", ephemeral=True)
-    if user.voice is None:
-        return
-    await user.edit(mute=False)
+    if user.voice:
+        await user.edit(mute=False)
 
 @bert.slash_command()
 @option("user", description="The user to send messages to")

--- a/bot/main.py
+++ b/bot/main.py
@@ -521,7 +521,7 @@ async def mute(interaction: discord.Interaction, user: discord.Member):
             f"{user.display_name} is already muted", ephemeral=True
         )
         return
-    if user in (await bert.application_info()).team.members or user.id in unmutables:
+    if user.id in unmutables or user in (await bert.application_info()).team.members:
         await interaction.response.send_message("nuh uh", ephemeral=True)
         return
     muted_users.add(user.id)
@@ -551,7 +551,7 @@ async def unmute(interaction: discord.Interaction, user: discord.Member):
             f"{user.display_name} is not muted", ephemeral=True
         )
         return
-    if user in (await bert.application_info()).team.members or user.id in unmutables:
+    if user.id in unmutables or user in (await bert.application_info()).team.members:
         await interaction.response.send_message("nuh uh", ephemeral=True)
         return
     muted_users.remove(user.id)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add mute and unmute commands to manage user voice states, including checks to prevent self-muting/unmuting and actions on bots or protected users.

New Features:
- Introduce a mute command to allow users to mute other members permanently, with checks to prevent self-muting, bot muting, and muting of certain protected users.
- Introduce an unmute command to allow users to unmute other members, with checks to prevent self-unmuting, bot unmuting, and unmuting of certain protected users.

<!-- Generated by sourcery-ai[bot]: end summary -->