### PR TITLE
Revert "Bump typescript from 5.6.2 to 5.7.2 in /website"

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19,7 +19,7 @@
 				"prettier": "^3.4.1",
 				"prettier-plugin-organize-imports": "^4.1.0",
 				"prettier-plugin-tailwindcss": "^0.6.8",
-				"typescript": "^5.7.2",
+				"typescript": "^5.6.2",
 				"vue": "^3.5.10",
 				"vue-router": "^4.5.0",
 				"vue-tsc": "^2.1.6"
@@ -12487,10 +12487,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-			"integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-			"license": "Apache-2.0",
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+			"integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,7 @@
 		"prettier": "^3.4.1",
 		"prettier-plugin-organize-imports": "^4.1.0",
 		"prettier-plugin-tailwindcss": "^0.6.8",
-		"typescript": "^5.7.2",
+		"typescript": "^5.6.2",
 		"vue": "^3.5.10",
 		"vue-router": "^4.5.0",
 		"vue-tsc": "^2.1.6"


### PR DESCRIPTION
Reverts codeman1o1/bert#69

## Summary by Sourcery

Chores:
- Revert the TypeScript version bump from 5.6.2 to 5.7.2 in the website package.